### PR TITLE
Add ability to modify link states

### DIFF
--- a/packages/base-typography/_typography.scss
+++ b/packages/base-typography/_typography.scss
@@ -66,6 +66,14 @@ $h4-size: 1.5#{$font-size-unit} !default;
 $h5-size: 1.25#{$font-size-unit} !default;
 $h6-size: 1#{$font-size-unit} !default;
 
+// Link states
+$anchor-link-color: #00E !default; // blue
+$anchor-visited-color: #551A8B !default; // purple
+$anchor-hover-color: #E00 !default; // red
+$anchor-active-color: #E00 !default; // red
+$anchor-link-decoration: underline !default;
+$anchor-hover-decoration: underline !default;
+
 
 //
 // Base Typography Styles
@@ -80,6 +88,32 @@ body {
   font-size: $base-font-size;
   line-height: $base-line-height;
   color: $base-text-color;
+}
+
+a {
+  &:link {
+    color: $anchor-link-color;
+    text-decoration: $anchor-link-decoration;
+    word-break: break-word;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+    cursor: pointer;
+    // touch-action: manipulation; // disable the delay of click events caused by support for the double-tap to zoom gesture
+  }
+  &:visited {
+    color: $anchor-visited-color;
+  }
+  &[href] {
+    &:hover {
+      color: $anchor-hover-color;
+      text-decoration: $anchor-hover-decoration;
+    }
+    &:active {
+      color: $anchor-active-color;
+    }
+  }
+  // &:focus {}
 }
 
 p,


### PR DESCRIPTION
This is like default behavior, additionally it breaks long URLs and it has one hover state which is same as active. I left :focus empty.